### PR TITLE
feat: support array versions

### DIFF
--- a/install.js
+++ b/install.js
@@ -69,5 +69,6 @@ function getTpl(name) {
 }
 
 function arrayify(str) {
-  return str.split(',').map(s => s.trim()).filter(s => !!s);
+  if (Array.isArray(str)) return str;
+  return str.split(/\s*,\s*/).filter(s => !!s);
 }

--- a/test/fixtures/array/package.json
+++ b/test/fixtures/array/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "egg-ci",
+  "version": "1.0.0",
+  "scripts": {
+    "ci": "npm run cov"
+  },
+  "ci": {
+    "type": [ "travis" ],
+    "version": [ 1, 2, 4, 5 ],
+    "npminstall": false
+  }
+}

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -19,6 +19,17 @@ test('travis and npminstall = false', t => {
   t.falsy(fs.existsSync(getYml('travis', 'appveyor.yml')));
 });
 
+test('travis and versions in array', t => {
+  const env = Object.assign({}, process.env, {CI_ROOT_FOR_TEST: getRoot('array')});
+  execSync(cmd, {env});
+  const yml = fs.readFileSync(getYml('travis', '.travis.yml'), 'utf8');
+  t.regex(yml, /\- '1'/);
+  t.regex(yml, /\- '2'/);
+  t.regex(yml, /\- '4'/);
+  t.regex(yml, /\- '5'/);
+  t.falsy(fs.existsSync(getYml('travis', 'appveyor.yml')));
+});
+
 test('default', t => {
   const env = Object.assign({}, process.env, {CI_ROOT_FOR_TEST: getRoot('default')});
   execSync(cmd, {env});


### PR DESCRIPTION
现在用的也可以直接迁移过来。

另外如果源站不是 cnpm，npminstall 可能没法用，如果依赖里包含 scoped 的模块就悲剧了
