### PR TITLE
fix: use npminstall to install codecov

### DIFF
--- a/templates/travis
+++ b/templates/travis
@@ -13,4 +13,4 @@ install:
 script:
   - npm run ci
 after_script:
-  - npm i codecov && codecov
+  - npminstall codecov && codecov


### PR DESCRIPTION
It's slow in Node6

https://travis-ci.com/eggjs/egg-session/jobs/45295555